### PR TITLE
feat: add WidgetKit extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Scoreboards
+
+watchOS app + widget for tracking two-team scores.
+
+## Tech Stack
+
+- Swift 5.0+, SwiftUI
+- watchOS 7.0+ deployment target
+- WidgetKit (complications)
+- Xcode project (no SPM/CocoaPods)
+
+## Project Structure
+
+```
+Scoreboards Watch App/   # Main watchOS app
+  ScoreboardsApp.swift   # Entry point, deep link handler (scoreboards://open)
+  ScoreboardsView.swift  # Root view, TeamScoreView component
+
+Scoreboards Widget/      # WidgetKit extension
+  ScoreboardsWidget.swift        # Timeline provider, widget UI (circular + corner)
+  ScoreboardsWidgetBundle.swift  # Widget bundle entry
+  AppIntent.swift                # Placeholder, not yet implemented
+```
+
+## Architecture
+
+Two targets sharing no code module — widget reads no live data (static timeline). Widget taps deep-link to app via `scoreboards://open`, handled in `ScoreboardsApp.swift:15` `onOpenURL`.
+
+State lives entirely in `ScoreboardsView`: `scoreTeam1`, `scoreTeam2`, `lastTeamScoring` — no persistence layer.
+
+## Key Behaviors
+
+- Score increment/decrement via `Stepper` in `TeamScoreView`
+- Last scoring team highlighted green (`lastTeamScoring` state)
+- Reset: 1.5s long press
+- Widget: two complication styles (circular, corner), static, taps open app
+
+## No Tests
+
+No test targets exist.
+
+## Build
+
+Open `Scoreboards.xcodeproj` in Xcode. Select watch simulator or paired device. Build & run.


### PR DESCRIPTION
## Summary

- Adds full WidgetKit extension target with circular and corner complications
- Deep links back to app via `scoreboards://open` on tap
- Includes app icons, accent color, and widget background assets
- `AppIntent.swift` placeholder for future interactive widget support

## Test plan

- [ ] Build and run on Apple Watch simulator
- [ ] Verify complications appear in watch face editor (circular + corner)
- [ ] Tap complication → app opens
- [ ] Long press reset still works in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)